### PR TITLE
Health endpoint ahead of the HTTPS redirect, and an App Platform spec

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,88 @@
+# DigitalOcean App Platform spec.
+#
+#     doctl apps create --spec .do/app.yaml
+#     doctl apps update <app-id> --spec .do/app.yaml
+#
+# This exists because the create wizard cannot express what this repo needs: the Dockerfile
+# lives in the project directory but its COPY paths are relative to the solution directory
+# one level up, since it copies six .csproj files and ClientApp before restoring. source_dir
+# sets the build context, dockerfile_path is resolved from the repo root, and only a spec
+# lets the two differ - point the wizard's "source directory" at the Dockerfile's folder and
+# detection succeeds but every COPY then fails.
+name: webchat
+region: fra
+
+services:
+  - name: web
+    github:
+      repo: borschetsky/WebChat
+      branch: master
+      deploy_on_push: true
+
+    # The build context. Not the Dockerfile's own directory - see the note above.
+    source_dir: WebChat
+    dockerfile_path: WebChat/WebChat/Dockerfile
+
+    http_port: 8080
+    instance_count: 1
+    instance_size_slug: apps-s-1vcpu-1gb
+
+    # Registered ahead of UseHttpsRedirection in Startup.Configure, so it answers 200 to a
+    # probe that arrives as plain HTTP with no X-Forwarded-Proto. Any other path would be
+    # answered with a 307 and counted as a failed check, rolling back a healthy deploy.
+    health_check:
+      http_path: /health
+
+    envs:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+
+      # The platform terminates TLS and forwards plain HTTP on this port.
+      - key: ASPNETCORE_URLS
+        value: http://+:8080
+
+      # Without this the app sees `http`, redirects to `https`, and the platform forwards
+      # `http` again - an infinite redirect. Safe here only because App Platform overwrites
+      # X-Forwarded-* on the way in.
+      - key: ForwardedHeaders__Enabled
+        value: "true"
+
+      # SignalR sends credentials, so the origin has to be listed explicitly; a wildcard is
+      # not allowed with AllowCredentials. ${APP_URL} is substituted by the platform.
+      - key: Cors__AllowedOrigins__0
+        value: ${APP_URL}
+
+      # Npgsql wants key/value, while the database component exposes a postgresql:// URI -
+      # hence composing it from the parts. Managed Postgres requires TLS.
+      - key: ConnectionStrings__DefaultConnection
+        scope: RUN_TIME
+        value: Host=${db.HOSTNAME};Port=${db.PORT};Database=${db.DATABASE};Username=${db.USERNAME};Password=${db.PASSWORD};SSL Mode=Require;Trust Server Certificate=true
+
+      # Startup.ValidateRequiredConfiguration refuses to boot without this outside
+      # Development. Generate with: openssl rand -base64 48
+      - key: JWTSecretKey
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+
+      # Avatars. With any of these absent the app falls back to local disk, which App
+      # Platform wipes on every deploy - so all three must be set here.
+      - key: R2__AccountId
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: R2__AccessKeyId
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: R2__SecretAccessKey
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+
+databases:
+  - name: db
+    engine: PG
+    version: "16"
+    # Dev database: single node, no backups, cheapest tier. Set true for a managed cluster.
+    production: false

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -24,8 +24,15 @@ services:
     dockerfile_path: WebChat/WebChat/Dockerfile
 
     http_port: 8080
+
+    # Must stay at 1. SignalR here has no backplane, so with two instances a message sent by
+    # a client on one container never reaches a client connected to the other - the app looks
+    # fine and silently drops half the conversation. Scaling out needs a Redis backplane
+    # first. The wizard defaults to 2, which is both wrong and double the price.
     instance_count: 1
-    instance_size_slug: apps-s-1vcpu-1gb
+
+    # Slug names change; pick the cheapest 512 MB tier in the UI if this one is rejected.
+    instance_size_slug: apps-s-1vcpu-512mb
 
     # Registered ahead of UseHttpsRedirection in Startup.Configure, so it answers 200 to a
     # probe that arrives as plain HTTP with no X-Forwarded-Proto. Any other path would be
@@ -36,6 +43,14 @@ services:
     envs:
       - key: ASPNETCORE_ENVIRONMENT
         value: Production
+
+      # The Web SDK turns Server GC on by default (System.GC.Server is true in
+      # WebChat.runtimeconfig.json), which reserves a heap per core and is sized for a
+      # machine, not a 512 MB container - the usual result is an OOM kill under light load.
+      # Workstation GC trades a little throughput for a much smaller footprint. Drop this if
+      # the instance is ever moved to 1 GB or more.
+      - key: DOTNET_gcServer
+        value: "0"
 
       # The platform terminates TLS and forwards plain HTTP on this port.
       - key: ASPNETCORE_URLS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,16 @@ and fill it in, or the command stops naming the variable it wanted.
   instead of reading that directory. `IncludeSpaOutput` now fails the publish when `dist` is
   empty. Docker passes `-p:SkipSpaBuild=true` and builds the SPA in a Node stage, because
   the .NET SDK image has no Node.
-- **Behind a TLS-terminating proxy, set `ForwardedHeaders__Enabled=true`.** The platform
-  answers HTTPS and forwards plain HTTP, so `UseHttpsRedirection` sees `http`, redirects to
-  `https`, and the proxy forwards `http` again — an infinite loop. It is off by default
-  because enabling it clears the known-proxy lists, which means trusting `X-Forwarded-*`
-  from anyone.
+- **Behind a TLS-terminating proxy, set `ForwardedHeaders__Enabled=true` and point the
+  platform's health check at `/health`.** The platform answers HTTPS and forwards plain
+  HTTP, so `UseHttpsRedirection` sees `http`, redirects to `https`, and the proxy forwards
+  `http` again — an infinite loop. The flag is off by default because enabling it clears the
+  known-proxy lists, which means trusting `X-Forwarded-*` from anyone. `/health` is
+  registered *ahead* of `UseHttpsRedirection` so it answers 200 regardless of scheme: a
+  probe from inside the platform's network carries no `X-Forwarded-Proto`, would otherwise
+  get a 307, and would roll back a deployment that is in fact healthy. Keep it shallow — the
+  app cannot start without a reachable database, so probing one here only adds a way for a
+  transient fault to kill a working instance.
 - **Secrets are supplied per runner, never committed.** Visual Studio reads
   `appsettings.Secrets.json`; docker compose reads `WebChat/.env`; a deployment sets
   environment variables. All three land on the same keys, because ASP.NET Core maps `__` to

--- a/WebChat/WebChat/Startup.cs
+++ b/WebChat/WebChat/Startup.cs
@@ -101,6 +101,7 @@ namespace WebChat
             services.AddControllers().AddNewtonsoftJson();
             services.AddSwaggerGen();
             services.AddRazorPages();
+            services.AddHealthChecks();
 
             services.AddSpaStaticFiles(configuration =>
             {
@@ -261,6 +262,20 @@ namespace WebChat
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
+
+            // Deliberately ahead of UseHttpsRedirection, so it answers regardless of scheme.
+            //
+            // A hosting platform probes this over plain HTTP from inside its own network,
+            // where there is no TLS to terminate and no X-Forwarded-Proto to set. Behind
+            // UseHttpsRedirection such a probe is answered with a 307, which a health check
+            // counts as a failure - so a perfectly healthy instance gets marked unhealthy and
+            // the deployment is rolled back, with the app itself giving no sign of trouble.
+            //
+            // The check is shallow on purpose: it reports that the process is up and serving,
+            // nothing more. The app already refuses to start without a reachable database -
+            // PrepDB migrates before the host runs - so probing the database here would only
+            // add a way for a transient fault to have a working instance killed.
+            app.UseHealthChecks("/health");
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();


### PR DESCRIPTION
Follows PR #12, which is merged. Three commits that a deploy needs before it can succeed.

## `/health` ahead of `UseHttpsRedirection`

**Deploy-blocking.** A hosting platform probes the container from inside its own network over plain HTTP — no TLS to terminate, so no `X-Forwarded-Proto`. Behind `UseHttpsRedirection` that probe is answered with a **307**, which a health check counts as a failure: a healthy instance is marked unhealthy and the deployment rolled back, while the app itself gives no sign of trouble.

Registering `/health` ahead of the redirect makes it answer regardless of scheme. Shallow on purpose — it reports that the process is up, nothing more. `PrepDB` migrates before the host runs, so the app cannot start without a reachable database, and probing one here would only add a way for a transient fault to have a working instance killed.

Verified against the built image on Production: `/health` returns 200 over plain HTTP with no forwarded header, while `/` and `/api/…` still return 307, so HTTPS enforcement is unchanged for everything else.

## `.do/app.yaml`

The create wizard cannot express this repo's build. The Dockerfile lives in the project directory but its `COPY` paths are relative to the solution directory one level up, because it copies six `.csproj` files and `ClientApp` before restoring. A spec separates the two — `source_dir` is the build context, `dockerfile_path` resolves from the repo root — where the wizard offers a single source directory, which detects the Dockerfile but then fails every `COPY`.

It also carries the two settings a deploy silently needs: `ForwardedHeaders__Enabled`, without which the app redirects forever behind the platform's TLS termination, and the health check path above.

## Sizing

`instance_count: 1` is a correctness constraint, not a cost one — SignalR has no backplane, so with two containers a message from a client on one never reaches a client on the other, silently. The wizard defaults to 2.

512 MB with `DOTNET_gcServer=0`: the Web SDK enables Server GC by default (`System.GC.Server` is `true` in `WebChat.runtimeconfig.json`), which reserves a heap per core sized for a machine rather than a small container and tends to get OOM-killed under light load.

## Not verified

Nothing has been deployed yet. The App Platform behaviour above is reasoned from how TLS-terminating proxies work, not observed — the health-check fix is precisely to de-risk the first attempt. Instance size slug and Postgres version in the spec may need adjusting to whatever DO currently offers.