### PR TITLE
Show the forgot-password link, and stop leaking field names at users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,4 +336,10 @@ appsettings.Secrets.json
 
 # Read automatically by docker compose from WebChat/. Holds the real database password, JWT
 # signing key and R2 credentials; WebChat/.env.example is the committed template.
+#
+# The glob matters as much as the bare name. A plain `.env` entry does not cover .env.bak,
+# .env.local or .env.save - and a backup taken while swapping credentials around is exactly
+# as secret as the original. One was committed once; only the example is exempt.
 .env
+.env.*
+!.env.example

--- a/WebChat/WebChat/ClientApp/src/app/App.jsx
+++ b/WebChat/WebChat/ClientApp/src/app/App.jsx
@@ -93,6 +93,7 @@ function AppRoutes() {
             busy={busy}
             onSubmit={signIn}
             onSwitch={() => navigate('/register')}
+            onForgotPassword={() => navigate('/forgot-password')}
             onNeedsConfirmation={(email) => {
               // The API answered 403 email_not_confirmed. Reuse the post-registration
               // screen: the situation and the way out of it are identical.

--- a/WebChat/WebChat/ClientApp/src/features/auth/AuthScreen.jsx
+++ b/WebChat/WebChat/ClientApp/src/features/auth/AuthScreen.jsx
@@ -5,6 +5,27 @@ import {
 import ForumIcon from '@mui/icons-material/Forum';
 
 /**
+ * Server validation messages, rewritten for the person reading them.
+ *
+ * ASP.NET phrases its messages after the C# property, so a missing sign-in field reads
+ * "The Identifier field is required." - which names an internal detail at someone who is
+ * only trying to sign in. `default` covers every message for that field; a specific key
+ * overrides it. Unrecognised messages pass through unchanged rather than being swallowed.
+ */
+const FRIENDLY = [
+  { field: 'identifier', match: /required/i, text: 'Enter your email address or username.' },
+  { field: 'email', match: /required/i, text: 'Enter your email address.' },
+  { field: 'email', match: /valid e-?mail/i, text: 'That does not look like an email address.' },
+  { field: 'username', match: /required/i, text: 'Choose a username.' },
+  { field: 'username', match: /minimum length|string or array/i, text: 'Usernames are 3 to 60 characters.' },
+  { field: 'password', match: /required/i, text: 'Enter your password.' },
+  { field: 'password', match: /minimum length|string or array/i, text: 'Passwords are at least 6 characters.' },
+];
+
+const friendly = (field, raw) =>
+  FRIENDLY.find((rule) => rule.field === field && rule.match.test(raw))?.text ?? raw;
+
+/**
  * Shared sign-in / sign-up card, matching the handoff's login screen: centred 420px Paper,
  * radius 16, outlined fields, contained submit.
  *
@@ -44,7 +65,15 @@ export default function AuthScreen({ mode, onSubmit, onSwitch, busy, onNeedsConf
 
       if (data.errors) {
         const flat = {};
-        Object.entries(data.errors).forEach(([k, v]) => { flat[k.toLowerCase()] = Array.isArray(v) ? v[0] : v; });
+        Object.entries(data.errors).forEach(([k, v]) => {
+          const field = k.toLowerCase();
+          const raw = Array.isArray(v) ? v[0] : v;
+          // ASP.NET phrases these after the C# property - "The Identifier field is
+          // required." - which names an internal detail at someone who is just trying to
+          // sign in. Replace the ones we know; pass anything else through rather than
+          // swallowing a message we have not seen.
+          flat[field] = friendly(field, raw);
+        });
         setErrors(flat);
         return;
       }
@@ -72,7 +101,7 @@ export default function AuthScreen({ mode, onSubmit, onSwitch, busy, onNeedsConf
 
           {isRegister && (
             <TextField
-              label="Username" fullWidth autoComplete="username"
+              label="Username" fullWidth required autoComplete="username"
               value={username} onChange={(e) => setUsername(e.target.value)}
               error={!!errors.username} helperText={errors.username}
             />
@@ -84,6 +113,7 @@ export default function AuthScreen({ mode, onSubmit, onSwitch, busy, onNeedsConf
             label={isRegister ? 'Email' : 'Email or username'}
             type={isRegister ? 'email' : 'text'}
             fullWidth
+            required
             autoComplete={isRegister ? 'email' : 'username'}
             value={email} onChange={(e) => setEmail(e.target.value)}
             error={!!(errors.email || errors.identifier)}
@@ -91,7 +121,7 @@ export default function AuthScreen({ mode, onSubmit, onSwitch, busy, onNeedsConf
           />
 
           <TextField
-            label="Password" type="password" fullWidth
+            label="Password" type="password" fullWidth required
             autoComplete={isRegister ? 'new-password' : 'current-password'}
             value={password} onChange={(e) => setPassword(e.target.value)}
             error={!!errors.password} helperText={errors.password}


### PR DESCRIPTION
Two bugs on the sign-in screen, both found by looking at it rather than by any test.

## The forgot-password link could never render

`App.jsx` never passed `onForgotPassword` to `AuthScreen`, so the guard `!isRegister && onForgotPassword` was always false. Password reset shipped in #31 **with no way to reach it from the UI**.

Worth recording how it slipped through: my check for the insertion was a substring search for `forgot-password`, which matched the *route path* I had added rather than the *prop* I had not. That is the third time in this session a substring check reported an insertion that never happened — the earlier two were a `UserService` method and a pair of `useCallback` definitions, both caught the same way, by something failing later.

## `"The Identifier field is required."`

ASP.NET phrases validation messages after the C# property, so an empty submit read out the internal field name to someone trying to sign in.

Known messages are now rewritten by pattern rather than exact string:

| Server | Shown |
|---|---|
| `The Identifier field is required.` | Enter your email address or username. |
| `The field Password must be a string or array type with a minimum length of 6.` | Passwords are at least 6 characters. |
| `invalid password` | *(unchanged — passes through)* |

Pattern matching rather than string equality because the second message above is not one anyone would guess, and exact keys would silently miss it. Unrecognised messages pass through rather than being swallowed, so anything new still reaches the user instead of vanishing.

All three inputs are now `required`, so an empty form never reaches the server at all.

## `.gitignore`

Widened from `.env` to `.env.*` with `!.env.example`. A plain `.env` entry does not cover `.env.bak`, `.env.local` or `.env.save` — and a backup taken while swapping credentials around is exactly as secret as the original. I hit this directly: an earlier version of this commit included `WebChat/.env.bak` with a live SMTP key. Caught before pushing; the file is untracked and history is clean.

## Verified

Typecheck clean, 60 client tests, production build succeeds. The link renders and the messages are readable in the running app.

One thing worth knowing for anyone testing this locally: the container's Vite was serving a **stale `App.jsx`** from its transform cache, so no amount of browser reloading showed the fix. `docker compose restart react-app` was the answer. Checking what the dev server serves —

```
curl -s http://localhost:3000/src/app/App.jsx | grep onForgotPassword
```

— locates that in one step, where guessing at browser caching does not.