### PR TITLE
Serve the app on chat.vtechsolutions.site and send email from the domain

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -12,6 +12,14 @@
 name: webchat
 region: fra
 
+# DNS lives at the registrar rather than DigitalOcean, so there is deliberately no `zone:`
+# here - with one, DigitalOcean expects to manage the zone itself. Instead it waits for an
+# externally-managed CNAME (`chat` -> the app's ondigitalocean.app hostname) and issues a
+# Let's Encrypt certificate once it verifies.
+domains:
+  - domain: chat.vtechsolutions.site
+    type: PRIMARY
+
 services:
   - name: web
     github:
@@ -68,6 +76,14 @@ services:
       - key: Cors__AllowedOrigins__0
         value: ${APP_URL}
 
+      # The custom domain is a separate origin. SignalR sends credentials, so the policy uses
+      # AllowCredentials() and a wildcard is not permitted - an unlisted origin fails to
+      # connect and presents as "chat is broken" rather than as a CORS error. The
+      # ondigitalocean.app origin stays listed: it remains valid, and removing it while
+      # testing is an easy way to lock yourself out of a working URL.
+      - key: Cors__AllowedOrigins__1
+        value: https://chat.vtechsolutions.site
+
       # Npgsql wants key/value, while the database component exposes a postgresql:// URI -
       # hence composing it from the parts. Managed Postgres requires TLS.
       - key: ConnectionStrings__DefaultConnection
@@ -106,13 +122,20 @@ services:
         scope: RUN_TIME
         type: SECRET
         value: REPLACE_ME
+      # Must be on a domain authenticated with the provider. A gmail.com sender relayed
+      # through Brevo fails both SPF and DKIM alignment - nothing but Google can authenticate
+      # as gmail.com - so DMARC fails and the mail lands in spam. Verified from this address:
+      # SPF, DKIM and DMARC all pass, and it reaches the inbox.
       - key: Email__FromAddress
         scope: RUN_TIME
-        value: REPLACE_ME
+        value: noreply@vtechsolutions.site
 
-      # Base for the confirmation link. Must be the public address, or every link 404s.
+      # Base for the confirmation link. Set explicitly rather than left as ${APP_URL}: if that
+      # does not follow the PRIMARY domain, every activation and reset link keeps pointing at
+      # the ondigitalocean.app hostname - which works, and quietly undoes the point of having
+      # a domain at all.
       - key: App__PublicUrl
-        value: ${APP_URL}
+        value: https://chat.vtechsolutions.site
 
 databases:
   - name: db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,18 @@ and fill it in, or the command stops naming the variable it wanted.
   instead of reading that directory. `IncludeSpaOutput` now fails the publish when `dist` is
   empty. Docker passes `-p:SkipSpaBuild=true` and builds the SPA in a Node stage, because
   the .NET SDK image has no Node.
+- **The app runs at `https://chat.vtechsolutions.site`** on DigitalOcean App Platform, with
+  `.do/app.yaml` as the source of truth for its configuration. DNS is at the registrar, not
+  DigitalOcean. Two settings are load-bearing and easy to miss when adding an origin:
+  `Cors__AllowedOrigins__n` must list it, or SignalR silently fails to connect — the policy
+  uses `AllowCredentials()`, so a wildcard is not permitted, and it presents as "chat is
+  broken" rather than as a CORS error. And `App__PublicUrl` is what activation and reset
+  links are built from, so it must be the address a browser can reach.
+- **Outbound mail must come from an authenticated domain.** A `gmail.com` sender relayed
+  through Brevo fails SPF and DKIM alignment — nothing but Google can authenticate as
+  gmail.com — so DMARC fails and activation email lands in spam. Sending from
+  `noreply@vtechsolutions.site` with Brevo's DKIM records published passes all three. Never
+  set `Email__FromAddress` to an address on a domain someone else controls.
 - **Behind a TLS-terminating proxy, set `ForwardedHeaders__Enabled=true` and point the
   platform's health check at `/health`.** The platform answers HTTPS and forwards plain
   HTTP, so `UseHttpsRedirection` sees `http`, redirects to `https`, and the proxy forwards


### PR DESCRIPTION
Implements #30, and closes the delivery problem that has been open against #25 since email activation shipped.

## The bug this actually fixes

**Activation email had been landing in spam every time.** Not the template, not the provider — the sender was a `gmail.com` address relayed through Brevo, and **nothing but Google can authenticate as gmail.com**. SPF and DKIM alignment both failed, so DMARC failed. No code change could have fixed it; it needed a domain we control.

Now sending from `noreply@vtechsolutions.site`. Verified end to end from production:

```
SPF:   PASS
DKIM:  PASS
DMARC: PASS
```

**and it reaches the inbox.**

## What was set up

DNS stays at the registrar rather than moving to DigitalOcean — eight records, all verified against the authoritative nameserver before touching the app:

| Purpose | Record |
|---|---|
| App | `chat` CNAME → the app's ondigitalocean.app hostname |
| Ownership | `brevo-code` TXT on the root |
| DKIM | `brevo1._domainkey`, `brevo2._domainkey` CNAMEs |
| DMARC | `_dmarc` TXT at `p=none` |
| Branding | `em`, `r.em`, `img.em` CNAMEs |

`p=none` deliberately — monitor before enforcing. Starting at `quarantine` would silently discard your own mail if anything were misconfigured, with no way to notice.

**Brevo asked for no SPF record**, because DKIM alignment alone satisfies DMARC. That mattered: the registrar already publishes an email-forwarding SPF, and adding a second would have been a permanent error that fails SPF *entirely* — worse than not adding one. The existing record was left untouched, and I verified afterwards that exactly one SPF record remains.

## Two settings that fail silently

**`Cors__AllowedOrigins__1`.** The custom domain is a separate origin, and the policy uses `AllowCredentials()`, so a wildcard is not permitted. An unlisted origin means **SignalR simply does not connect** — it presents as "chat is broken", not as a CORS error. The `ondigitalocean.app` origin stays listed; removing it while testing is an easy way to lock yourself out of a working URL.

**`App__PublicUrl`** is set explicitly rather than left as `${APP_URL}`. If that does not follow the PRIMARY domain, every activation and reset link keeps pointing at the old hostname — which works, and quietly undoes the point of having a domain.

## Spec detail

No `zone:` on the domain entry. With one, DigitalOcean expects to manage the DNS zone itself; without it, it waits for an externally-managed CNAME and issues the certificate once it verifies. That is the correct shape when DNS lives at the registrar.

The committed spec now matches production, rather than describing an app with no domain.

## Verified

- `https://chat.vtechsolutions.site` — 200, valid certificate to 2026-11-03, `http` → 301 → `https`
- SignalR connects from the new origin (confirmed by the repo owner)
- Existing accounts still sign in; the `SecurityStamp` backfill from #31 held
- All eight DNS records confirmed at the authoritative nameserver, and exactly one SPF record

## Follow-ups

`Cors__AllowedOrigins__0` is still `${APP_URL}`. Harmless, and worth revisiting only if the `ondigitalocean.app` hostname is ever retired.