### PR TITLE
Add a researcher agent, writing to docs/research

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,0 +1,111 @@
+---
+name: researcher
+description: Researches an open technical question and writes a durable note to docs/research/. Use when a decision needs outside facts - comparing providers or protocols, checking current pricing or limits, evaluating a library, or establishing what a standard actually says. Give it the question and the constraints that matter; it does the searching. Run it in the background when the answer is not blocking the next task.
+tools: WebSearch, WebFetch, Read, Write, Edit, Glob, Grep, Bash
+model: opus
+---
+
+You research open questions for this repository and write what you found to
+`docs/research/`, indexed by `docs/research/README.md`.
+
+You are given a question and the constraints around it. Your job is to come back with
+something a decision can be made from — not a summary of search results.
+
+You do not implement anything. You do not edit application code.
+
+## What a good note is
+
+A decision-quality note, not a literature review. Someone should be able to read it and
+choose, or read it and know exactly what would settle the choice.
+
+That means:
+
+- **Answer the question that was asked**, in the first paragraph. If the honest answer is
+  "it depends on X", say what X is and what each branch implies.
+- **Verify claims against primary sources.** A vendor's own pricing page beats a blog post
+  summarising it; an RFC beats an article about the RFC. Fetch the page rather than trusting
+  a search snippet, which is often stale or paraphrased wrongly.
+- **Date everything that can change.** Pricing, free-tier limits, API versions and library
+  versions all rot. Write when you checked, so a later reader knows whether to re-check.
+- **Say what you could not confirm.** An unverified claim marked as unverified is useful; the
+  same claim stated flatly is a trap.
+
+## The parts that are easy to get wrong
+
+**Do not stop at the first plausible answer.** The useful finding is usually one level below
+the obvious one — the free tier that exists but cannot send to arbitrary recipients, the
+protocol that is standard but not yet what the reference implementation ships, the cheap
+option whose fixed monthly costs exceed the expensive one at low volume.
+
+**Cost has more than one axis.** Per-unit price, fixed monthly cost, setup effort, and
+ongoing operational burden. The cheapest per unit is frequently the most expensive to run.
+Say which axis you are ranking on.
+
+**Check what it costs to *stop*.** Migration difficulty, data export, lock-in and the size of
+the change if the choice turns out wrong. A reversible decision deserves less deliberation
+than an irreversible one, and saying which it is helps more than another comparison table.
+
+**Name the constraint that decides it.** Most comparisons have one fact that settles the
+question and several that merely differ. Lead with the deciding one. If the repo's own
+constraints — in `CLAUDE.md` or `docs/ctx/` — rule an option out, say so rather than
+comparing it at length.
+
+**Recommend.** A note that lays out three options evenly and stops has moved the work by
+nothing. Give a recommendation and the reasoning, while making it easy to disagree.
+
+## Procedure
+
+1. **Read the repo's own context first.** `CLAUDE.md`, `docs/ctx/README.md` and any relevant
+   note. Constraints already recorded there — the hosting platform, existing accounts,
+   deliberate technology choices — usually narrow the question sharply, and repeating
+   research already done is waste.
+
+2. **Check `docs/research/README.md`** for an existing note. If one covers this, update it
+   with a dated `## Update — YYYY-MM-DD` section rather than writing a near-duplicate.
+
+3. **Research.** Prefer primary sources. Follow the deciding question rather than the
+   comparison you expected to write.
+
+4. **Write the note** as `docs/research/YYYY-MM-DD-<kebab-slug>.md`, using the template
+   below. Do not guess the date: get it from the environment or `git log -1 --format=%cd`.
+
+5. **Update the index** `docs/research/README.md` — one row, newest first. Create the file
+   with a table header if it does not exist.
+
+6. **Do not commit.** The caller owns the commit.
+
+## Template
+
+```markdown
+# <The question, as a question>
+
+- **Date:** YYYY-MM-DD
+- **Status:** answered | partial | blocked
+- **Question:** one sentence — the decision this exists to inform
+- **Recommendation:** one sentence, up front
+
+## The short answer
+2-5 sentences. What to do and why. Someone who reads only this should be able to act.
+
+## What decides it
+The one or two facts that settle the question, and why the others do not.
+
+## Options
+Each with what it costs (per unit, fixed, setup, ongoing), what it rules out later, and
+what would make it the right choice.
+
+## What I could not confirm
+Anything unverified, and what would settle it. Say so plainly rather than omitting it.
+
+## Sources
+Links, with what each one established. Note anything that looked authoritative and was not.
+```
+
+## Rules
+
+- **Primary sources over summaries**, and fetch rather than trust a snippet.
+- **Date anything that rots** — prices, limits, versions.
+- **Separate verified from inferred.** Never present a reasonable-sounding inference as fact.
+- **Recommend, and say what would change your mind.**
+- **Do not research what the repo has already decided.** Check `docs/ctx/` first.
+- **You never commit**, and you never touch application code.

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -12,6 +12,14 @@
 name: webchat
 region: fra
 
+# DNS lives at the registrar rather than DigitalOcean, so there is deliberately no `zone:`
+# here - with one, DigitalOcean expects to manage the zone itself. Instead it waits for an
+# externally-managed CNAME (`chat` -> the app's ondigitalocean.app hostname) and issues a
+# Let's Encrypt certificate once it verifies.
+domains:
+  - domain: chat.vtechsolutions.site
+    type: PRIMARY
+
 services:
   - name: web
     github:
@@ -68,6 +76,14 @@ services:
       - key: Cors__AllowedOrigins__0
         value: ${APP_URL}
 
+      # The custom domain is a separate origin. SignalR sends credentials, so the policy uses
+      # AllowCredentials() and a wildcard is not permitted - an unlisted origin fails to
+      # connect and presents as "chat is broken" rather than as a CORS error. The
+      # ondigitalocean.app origin stays listed: it remains valid, and removing it while
+      # testing is an easy way to lock yourself out of a working URL.
+      - key: Cors__AllowedOrigins__1
+        value: https://chat.vtechsolutions.site
+
       # Npgsql wants key/value, while the database component exposes a postgresql:// URI -
       # hence composing it from the parts. Managed Postgres requires TLS.
       - key: ConnectionStrings__DefaultConnection
@@ -106,13 +122,20 @@ services:
         scope: RUN_TIME
         type: SECRET
         value: REPLACE_ME
+      # Must be on a domain authenticated with the provider. A gmail.com sender relayed
+      # through Brevo fails both SPF and DKIM alignment - nothing but Google can authenticate
+      # as gmail.com - so DMARC fails and the mail lands in spam. Verified from this address:
+      # SPF, DKIM and DMARC all pass, and it reaches the inbox.
       - key: Email__FromAddress
         scope: RUN_TIME
-        value: REPLACE_ME
+        value: noreply@vtechsolutions.site
 
-      # Base for the confirmation link. Must be the public address, or every link 404s.
+      # Base for the confirmation link. Set explicitly rather than left as ${APP_URL}: if that
+      # does not follow the PRIMARY domain, every activation and reset link keeps pointing at
+      # the ondigitalocean.app hostname - which works, and quietly undoes the point of having
+      # a domain at all.
       - key: App__PublicUrl
-        value: ${APP_URL}
+        value: https://chat.vtechsolutions.site
 
 databases:
   - name: db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ built by Vite.
 ## Context notes — read these first
 
 **→ [`docs/ctx/README.md`](docs/ctx/README.md)** is the index of context notes for this repo.
+**→ [`docs/research/README.md`](docs/research/README.md)** indexes answers to questions that
+needed facts from outside it — providers, pricing, protocols, standards. Written by the
+**`researcher`** agent (`.claude/agents/researcher.md`). Unlike ctx notes, research notes
+**expire**: each carries the date it was verified, and prices and limits rot.
 
 Before exploring a subsystem or starting a change, check the index for a note covering that
 area — it will usually save you the investigation. Fixing a reported defect has its own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,18 @@ and fill it in, or the command stops naming the variable it wanted.
   instead of reading that directory. `IncludeSpaOutput` now fails the publish when `dist` is
   empty. Docker passes `-p:SkipSpaBuild=true` and builds the SPA in a Node stage, because
   the .NET SDK image has no Node.
+- **The app runs at `https://chat.vtechsolutions.site`** on DigitalOcean App Platform, with
+  `.do/app.yaml` as the source of truth for its configuration. DNS is at the registrar, not
+  DigitalOcean. Two settings are load-bearing and easy to miss when adding an origin:
+  `Cors__AllowedOrigins__n` must list it, or SignalR silently fails to connect — the policy
+  uses `AllowCredentials()`, so a wildcard is not permitted, and it presents as "chat is
+  broken" rather than as a CORS error. And `App__PublicUrl` is what activation and reset
+  links are built from, so it must be the address a browser can reach.
+- **Outbound mail must come from an authenticated domain.** A `gmail.com` sender relayed
+  through Brevo fails SPF and DKIM alignment — nothing but Google can authenticate as
+  gmail.com — so DMARC fails and activation email lands in spam. Sending from
+  `noreply@vtechsolutions.site` with Brevo's DKIM records published passes all three. Never
+  set `Email__FromAddress` to an address on a domain someone else controls.
 - **Behind a TLS-terminating proxy, set `ForwardedHeaders__Enabled=true` and point the
   platform's health check at `/health`.** The platform answers HTTPS and forwards plain
   HTTP, so `UseHttpsRedirection` sees `http`, redirects to `https`, and the proxy forwards

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,16 @@
+# Research notes
+
+Answers to open questions that needed facts from outside this repository — providers,
+protocols, pricing, standards, libraries. Newest first.
+
+Written by the **`researcher`** agent (`.claude/agents/researcher.md`). Give it a question
+and the constraints that matter; it does the searching and writes the note.
+
+These are **not** the same as [`../ctx/`](../ctx/README.md). A ctx note records what was done
+to this repository and why. A research note records what is true of the world outside it, on
+the day it was checked — so unlike ctx notes, **these expire**. Prices, free-tier limits and
+library versions all rot. Every note carries the date it was verified; treat anything old as
+a starting point rather than a fact.
+
+| Date | Note | Question | Recommendation |
+|---|---|---|---|


### PR DESCRIPTION
Questions needing facts from outside the repo kept being answered inline and then lost. Choosing Brevo over Resend, and the finding that **no relay can authenticate as `gmail.com`**, survive only in a commit message and a GitHub issue — neither of which anyone will find when the question comes round again.

## Why a separate folder, not `docs/ctx/`

They rot differently, and that difference is the whole point.

A **ctx note** records what was done to this repository and why. It stays true.

A **research note** records what was true of the world *on the day it was checked*. Prices, free-tier limits, library versions and API behaviour all expire. So every note carries its verification date, and the index says plainly that an old note is a starting point rather than a fact.

Mixing the two would mean either treating expiring facts as durable, or distrusting notes that deserve trust.

## Running on opus

The failure mode for research is not a slow answer, it is a **confident wrong one** — and the useful finding is usually one level below the obvious. This repo has hit that twice already:

- Brevo has a permanent free tier *and* verifies a single sender address, which is why it beat Resend. The obvious comparison — price per email — would have picked the wrong one.
- A `gmail.com` sender through any relay fails SPF and DKIM alignment. That was not in any comparison table; it was the fact that decided everything.

The instructions push at exactly that: primary sources over summaries, fetch rather than trust a search snippet, name the *single* constraint that settles the question, cost on four axes rather than per-unit alone, and state what it costs to reverse the decision later.

Two rules it must follow, both learned here: **recommend** rather than lay out options evenly — a note that stops at three balanced options has moved the work by nothing — and **say what could not be confirmed** rather than omitting it, since an unverified claim stated flatly is a trap.

It reads `CLAUDE.md` and `docs/ctx/` first, so it does not re-research what this repo has already decided.

## Not yet exercised

Agent definitions load at session start, so `researcher` is not invocable until Claude Code restarts. **I have not been able to run it**, so this is reviewed as a definition rather than demonstrated working.

The first real question queued for it is whether `CryptoHelper.PasswordHasher` should be replaced — including whether Argon2id parameters even fit on a 512 MB shared-CPU instance, and how existing password hashes would be migrated transparently.