### PR TITLE
Carry the workspace role through the profile adapter

### DIFF
--- a/WebChat/WebChat/ClientApp/src/services/adapters.test.ts
+++ b/WebChat/WebChat/ClientApp/src/services/adapters.test.ts
@@ -284,6 +284,35 @@ describe('toDirectory and toProfile', () => {
     expect(p.name).toBe('');
     expect(p.email).toBe('');
   });
+
+  /**
+   * The workspace role has to survive this seam, and for five slices it did not.
+   *
+   * `/users/getprofile` has always sent it, but neither the DTO nor the view model declared
+   * it and the adapter dropped it, so `profile.role` was `undefined` for everybody. Both
+   * readers - the admin link in `SettingsDrawer` and the `/admin` route guard in `App.jsx` -
+   * live in `.jsx`, where nothing type-checks a property that does not exist, so an owner got
+   * no link *and* was redirected away from the URL. The whole console was unreachable from a
+   * browser while its API worked perfectly.
+   */
+  it('carries the workspace role through', () => {
+    const p = toProfile({
+      id: 'me',
+      username: 'Wod',
+      email: 'wod@example.com',
+      avatarFileName: null,
+      role: 'owner',
+    });
+
+    expect(p.role).toBe('owner');
+  });
+
+  it('degrades a roleless profile to null rather than inventing a role', () => {
+    // An older server, or a body that lost the field: deny rather than assume. isAdminRole
+    // reads null as "not an admin", which is the safe direction for a permission check.
+    const p = toProfile({ id: 'me', username: null, email: null, avatarFileName: null });
+    expect(p.role).toBeNull();
+  });
 });
 
 describe('currentUserId', () => {

--- a/WebChat/WebChat/ClientApp/src/services/adapters.ts
+++ b/WebChat/WebChat/ClientApp/src/services/adapters.ts
@@ -232,6 +232,11 @@ export const toProfile = (vm: ProfileDto): Profile => ({
   email: vm.email ?? '',
   avatarFileName: vm.avatarFileName ?? null,
   color: avatarColor(vm.id ?? ''),
+  // Load-bearing, and it was missing for five slices: the admin link and the /admin route
+  // guard both read it, so dropping it here made the console unreachable from a browser
+  // while its API answered perfectly. Read fresh from the database on every getprofile, so
+  // a promotion takes effect on reload rather than at the next sign-in.
+  role: vm.role ?? null,
 });
 
 /**

--- a/WebChat/WebChat/ClientApp/src/types/dto.ts
+++ b/WebChat/WebChat/ClientApp/src/types/dto.ts
@@ -22,6 +22,8 @@ export interface ProfileDto {
   username: string | null;
   email: string | null;
   avatarFileName: string | null;
+  /** Workspace role - 'owner' | 'admin' | 'member'. Optional: a server predating #68 omits it. */
+  role?: string | null;
 }
 
 /** UsersController search, HeyController getusers. */

--- a/WebChat/WebChat/ClientApp/src/types/models.ts
+++ b/WebChat/WebChat/ClientApp/src/types/models.ts
@@ -160,6 +160,11 @@ export interface Profile {
   email: string;
   avatarFileName: string | null;
   color: string;
+  /**
+   * Workspace role, as the server currently holds it - not as the token claimed at sign-in.
+   * `null` when absent, which `isAdminRole` reads as "not an admin".
+   */
+  role: string | null;
 }
 
 /** What the login flow persists to localStorage under 'user-data'. */


### PR DESCRIPTION
The admin console has been unreachable from a browser since #68 — not broken, *unreachable*. Its API answered every request correctly, which is why five slices of server work and a live `200` from `/api/admin/policies` all looked like success.

`/users/getprofile` has always sent the role:

```json
{ "id": "…", "username": "Wod", "email": "…", "role": "owner" }
```

But `ProfileDto` did not declare it, `Profile` did not declare it, and `toProfile` did not map it — so `profile.role` was `undefined` for everybody. Both readers live in `.jsx`, where nothing type-checks a property that doesn't exist:

- `SettingsDrawer.jsx:200` — `isAdminRole(profile?.role)` gates the admin link, so no link ever rendered
- `App.jsx:364` — the `/admin` route guard redirected even an owner to `/dashboard`

Same blind spot as the `inputProps` drift in `3d347de`: the components that matter are `.jsx`, so the type system never sees them. Here it cost a whole feature rather than an accessible name.

A roleless body maps to `null` rather than to a guess, so `isAdminRole` denies — the safe direction for a permission check is the one that closes the door.

Two tests added, both confirmed failing before the fix (`expected undefined to be 'owner'`). 188 client tests, `npm run verify` clean.